### PR TITLE
Added configuration of OAuth 2.0 accessTokenValiditySeconds

### DIFF
--- a/src/main/java/io/confluent/connect/http/security/OAuth2Config.java
+++ b/src/main/java/io/confluent/connect/http/security/OAuth2Config.java
@@ -18,6 +18,7 @@ package io.confluent.connect.http.security;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -85,6 +86,9 @@ public class OAuth2Config {
   @EnableAuthorizationServer
   @Slf4j
   protected static class AuthorizationServerConfiguration extends AuthorizationServerConfigurerAdapter {
+    @Value("${ACCESS_TOKEN_VALIDITY:" + Integer.MAX_VALUE + "}")
+    private int accessTokenValidity;
+
     @Autowired
     private AuthenticationManager authenticationManager;
 
@@ -114,7 +118,7 @@ public class OAuth2Config {
           .withClient(id)
           .secret(encodedSecret)
           .authorizedGrantTypes("client_credentials")
-          .accessTokenValiditySeconds(Integer.MAX_VALUE)
+          .accessTokenValiditySeconds(accessTokenValidity)
           .refreshTokenValiditySeconds(Integer.MAX_VALUE);
     }
   }


### PR DESCRIPTION
Added configurability via Spring/env ACCESS_TOKEN_VALIDITY.

The default access token expiry remains at Integer.MAX_VALUE, but can be modified e.g. by exporting environment ACCESS_TOKEN_VALIDITY=3600,
which would cause issued access tokens to expire in 1 hour.

This configuration feature is important when testing OAuth2 (client authentication) access token expiry.

For example, when launching using the built Docker image, you can:

```
  kafka-connect-http-demo:
    image: kafka-connect-http-demo
    hostname: kafka-connect-http-demo
    container_name: kafka-connect-http-demo
    ports:
      - "8080:8080"
    environment:
      SPRING_PROFILES_ACTIVE: "oauth2"
      ACCESS_TOKEN_VALIDITY: 120
```
... to make access token expiry occur after 2 minutes.