### PR TITLE
Removed -X for all curl-s that are GETs (return all messages)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This app is useful in testing the HTTP Sink Connector.
       -d message-goes-here
       
     # get all messages
-    curl -X POST http://localhost:8080/api/messages
+    curl http://localhost:8080/api/messages
     ```
 
 ## Basic Auth
@@ -50,7 +50,7 @@ This app is useful in testing the HTTP Sink Connector.
       -d message-goes-here
     
     # get all messages
-    curl -X POST \
+    curl \
       http://localhost:8080/api/messages \
       -H 'Authorization: Basic YWRtaW46cGFzc3dvcmQ='
     ```
@@ -79,7 +79,8 @@ This app is useful in testing the HTTP Sink Connector.
       -H 'Authorization: Bearer {token}'
       -d message-goes-here
       
-    curl -X GET \
+    # get all messages
+    curl \
         http://localhost:8080/api/messages \
         -H 'Authorization: Bearer {token}'
     ```


### PR DESCRIPTION
Removed two `-X POST` args from `curl` commands that are actually `GET`s (returns all messages).  These are invalid as `POST`s as they supply no body and return `400`.

Also removed one of these as `GET` - since that is implied.  In fact all `-X` could probably be removed, as the method is implied from other args like `-d`, but decided to limit the changes here, and just make the `GET`s consistent.